### PR TITLE
Neovim upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 plugin
 colors
-lsp_servers

--- a/lua/common/lsp.lua
+++ b/lua/common/lsp.lua
@@ -9,7 +9,7 @@ local capabilities = {
 plugins.use(
 	'cmp_nvim_lsp',
 	function (cmp)
-		capabilities.cmp = cmp.update_capabilities(capabilities.vim)
+		capabilities.cmp = cmp.default_capabilities(capabilities.vim)
 	end
 )
 

--- a/lua/common/lsp_installers/init.lua
+++ b/lua/common/lsp_installers/init.lua
@@ -1,9 +1,9 @@
 return {
 	clangd = require('common.lsp_installers.clangd'),
 	gopls = require('common.lsp_installers.gopls'),
+	lua_ls = require('common.lsp_installers.lua_ls'),
 	pylsp = require('common.lsp_installers.pylsp'),
 	rust_analyzer = require('common.lsp_installers.rust_analyzer'),
-	sumneko_lua = require('common.lsp_installers.sumneko_lua'),
 	tsserver = require('common.lsp_installers.tsserver'),
 }
 

--- a/lua/common/lsp_installers/lua_ls.lua
+++ b/lua/common/lsp_installers/lua_ls.lua
@@ -7,9 +7,9 @@ local check_dir_exists = require('common.lsp_installers.builder.check_dir_exists
 local path = require('common.path')
 local http = require('common.http')
 
-local server_name = 'sumneko_lua'
+local server_name = 'lua_ls'
 
-local url = 'https://github.com/sumneko/lua-language-server/releases/download/3.5.6/lua-language-server-3.5.6-linux-x64.tar.gz'
+local url = 'https://github.com/LuaLS/lua-language-server/releases/download/3.7.3/lua-language-server-3.7.3-linux-x64.tar.gz'
 
 local install_dir = path.lsp_servers..'/'..server_name
 local binary_path = install_dir..'/bin/lua-language-server'

--- a/lua/common/path.lua
+++ b/lua/common/path.lua
@@ -25,7 +25,7 @@ local function get_download_path()
 end
 
 local function get_lsp_server_dir()
-	return vim.fn.stdpath('config')..'/lsp_servers'
+	return vim.fn.stdpath('data')..'/lsp_servers'
 end
 
 local function get_plugins_dir()

--- a/lua/personal/lsp.lua
+++ b/lua/personal/lsp.lua
@@ -4,6 +4,6 @@ lsp.load_servers({
 	'clangd',
 	'gopls',
 	'rust_analyzer',
-	'sumneko_lua'
+	'lua_ls'
 })
 

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -24,7 +24,7 @@ plugins.load({
 	},
 	{
 		'hrsh7th/nvim-cmp',
-		commit = '4efecf7f5b86949de387e63fa86715bc39f92219'
+		commit = '538e37ba87284942c1d76ed38dd497e54e65b891'
 	},
 	{
 		'hrsh7th/cmp-buffer',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -20,7 +20,7 @@ plugins.load({
 	},
 	{
 		'L3MON4D3/LuaSnip',
-		commit = 'a45cd5f4d9dea7c64b37fa69dea91e46bbbe9671'
+		tag = '2.2.0'
 	},
 	{
 		'hrsh7th/nvim-cmp',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -36,7 +36,7 @@ plugins.load({
 	},
 	{
 		'hrsh7th/cmp-nvim-lsp',
-		commit = '134117299ff9e34adde30a735cd8ca9cf8f3db81'
+		commit = '5af77f54de1b16c34b23cba810150689a3a90312'
 	},
 	{
 		'neovim/nvim-lspconfig',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -48,7 +48,7 @@ plugins.load({
 	},
 	{
 		'Darazaki/indent-o-matic',
-		commit = '68f19ea15da7e944e7a5c848831837d2023b4ac2'
+		commit = '4d11e98f523d3c4500b1dc33f0d1a248a4f69719'
 	}
 })
 

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -16,7 +16,7 @@ plugins.load({
 	},
 	{
 		'numToStr/Comment.nvim',
-		tag = 'v0.6'
+		tag = 'v0.8.0'
 	},
 	{
 		'L3MON4D3/LuaSnip',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -2,7 +2,6 @@ local plugins = require('common.plugins')
 require 'personal.options'
 
 plugins.load({
-	'nvim-lua/popup.nvim',
 	'nvim-lua/plenary.nvim',
 	{
 		'rockerbacon/vim-noctu',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -12,7 +12,7 @@ plugins.load({
 	},
 	{
 		'nvim-telescope/telescope.nvim',
-		tag = 'nvim-0.6'
+		tag = 'v0.1.5'
 	},
 	{
 		'numToStr/Comment.nvim',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -28,7 +28,7 @@ plugins.load({
 	},
 	{
 		'hrsh7th/cmp-buffer',
-		commit = 'a0fe52489ff6e235d62407f8fa72aef80222040a'
+		commit = '3022dbc9166796b644a841a02de8dd1cc1d311fa'
 	},
 	{
 		'hrsh7th/cmp-path',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -2,7 +2,10 @@ local plugins = require('common.plugins')
 require 'personal.options'
 
 plugins.load({
-	'nvim-lua/plenary.nvim',
+	{
+		'nvim-lua/plenary.nvim',
+		tag = 'v0.1.4'
+	},
 	{
 		'rockerbacon/vim-noctu',
 		run = plugins.new_colorscheme_installer({ 'colors/noctu.vim' })

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -12,7 +12,7 @@ plugins.load({
 	},
 	{
 		'nvim-telescope/telescope.nvim',
-		tag = 'v0.1.5'
+		tag = '0.1.5'
 	},
 	{
 		'numToStr/Comment.nvim',
@@ -20,7 +20,7 @@ plugins.load({
 	},
 	{
 		'L3MON4D3/LuaSnip',
-		tag = '2.2.0'
+		tag = 'v2.2.0'
 	},
 	{
 		'hrsh7th/nvim-cmp',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -32,7 +32,7 @@ plugins.load({
 	},
 	{
 		'hrsh7th/cmp-path',
-		commit = '56a0fe5c46835ecc6323bda69f3924758b991590'
+		commit = '91ff86cd9c29299a64f968ebb45846c485725f23'
 	},
 	{
 		'hrsh7th/cmp-nvim-lsp',

--- a/lua/personal/plugins.lua
+++ b/lua/personal/plugins.lua
@@ -40,7 +40,7 @@ plugins.load({
 	},
 	{
 		'neovim/nvim-lspconfig',
-		tag = 'v0.1.2'
+		tag = 'v0.1.7'
 	},
 	{
 		'steelsojka/pears.nvim',

--- a/lua/work/init.lua
+++ b/lua/work/init.lua
@@ -1,7 +1,7 @@
 local HotLoader = require('common.hot_loader')
 local plugins = require('common.plugins')
 
-local loader = HotLoader.single('personal.init')
+local loader = HotLoader.single('work.init')
 
 loader:before_reloading(
 	'personal.plugins',

--- a/lua/work/lsp.lua
+++ b/lua/work/lsp.lua
@@ -3,7 +3,7 @@ local lsp = require('common.lsp')
 lsp.load_servers({
 	'clangd',
 	'pylsp',
-	'sumneko_lua',
+	'lua_ls',
 	'tsserver'
 })
 


### PR DESCRIPTION
Deprecates Neovim 0.6 in favour of version 0.9. Plugins have been upgraded accordingly.

This will remain as a draft until it proves itself to be stable.